### PR TITLE
Datepicker row now visble, at start disable it

### DIFF
--- a/composeApp/src/desktopMain/kotlin/Main.kt
+++ b/composeApp/src/desktopMain/kotlin/Main.kt
@@ -76,6 +76,10 @@ fun main() {
                         preferencesStore.pdfOutputPath = writeAndOpenMainDocument(preferencesStore)
                     }
 
+                    if (preferencesStore.startDateIsEnabled) {
+                        preferencesStore.startDateIsEnabled = false
+                    }
+
                     // Error handling
                     if (preferencesV2external == null && preferencesStoreExternal != null) {
                         PreferenceExceptionScreen(preferencesStoreExternal)

--- a/composeApp/src/desktopMain/kotlin/screens/Start.kt
+++ b/composeApp/src/desktopMain/kotlin/screens/Start.kt
@@ -69,9 +69,7 @@ fun start(
                 }
             }
             Divider()
-            Row {
-                DatePickerRow(preferencesStore)
-            }
+            DatePickerRow(preferencesStore)
             Row {
                 Button(
                     onClick = { requestNewAppState(AppState.LICENSE) },


### PR DESCRIPTION
Disable it at start because it can be confusing when you come back at a later stage and the wrong week is selected.